### PR TITLE
Add support for MultipleMediaPicker and Nested Content (v7)

### DIFF
--- a/Conveyor/AST.ContentConveyor7/AST.ContentConveyor7.csproj
+++ b/Conveyor/AST.ContentConveyor7/AST.ContentConveyor7.csproj
@@ -79,6 +79,7 @@
     <Compile Include="DataTypeConverters\DropdownListDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\MediaPickerDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\MultiNodeTreePickerDataTypeConverter.cs" />
+    <Compile Include="DataTypeConverters\MultipleMediaPickerDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\RichTextEditorDataTypeConverter.cs" />
     <Compile Include="Enums\ActionTypes.cs" />
     <Compile Include="Enums\ObjectTypes.cs" />

--- a/Conveyor/AST.ContentConveyor7/AST.ContentConveyor7.csproj
+++ b/Conveyor/AST.ContentConveyor7/AST.ContentConveyor7.csproj
@@ -79,6 +79,8 @@
     <Compile Include="DataTypeConverters\DropdownListDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\MediaPickerDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\MultiNodeTreePickerDataTypeConverter.cs" />
+    <Compile Include="DataTypeConverters\BaseNestedDataTypeConverter.cs" />
+    <Compile Include="DataTypeConverters\NestedContentDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\MultipleMediaPickerDataTypeConverter.cs" />
     <Compile Include="DataTypeConverters\RichTextEditorDataTypeConverter.cs" />
     <Compile Include="Enums\ActionTypes.cs" />

--- a/Conveyor/AST.ContentConveyor7/DataTypeConverters/BaseNestedDataTypeConverter.cs
+++ b/Conveyor/AST.ContentConveyor7/DataTypeConverters/BaseNestedDataTypeConverter.cs
@@ -1,0 +1,57 @@
+﻿namespace AST.ContentConveyor7.DataTypeConverters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using AST.ContentConveyor7;
+    using AST.ContentConveyor7.Enums;
+    using AST.ContentConveyor7.Utilities;
+
+    using Umbraco.Core.Models;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Base class for recursive converters that process a chunk of data (usually JSON)
+    /// and need to internally invoke other Type Converters
+    /// </summary>
+    /// <remarks>
+    /// Provides two wrapper methods for invoking the Export and Import operation on a nested data type
+    /// </remarks>
+    public class BaseNestedTypeConverter : BaseContentManagement
+    {
+        /// <summary>
+        /// Invokes the Type Converter Export for an individual value inside the nested data type
+        /// </summary>
+        protected string NestedExport(IDataTypeConverter typeConverter, string value, PropertyType propertyType, Dictionary<int, ObjectTypes> dependantNodes)
+        {
+            // recursively invoke the TypeConverter
+            Property property = new Property(propertyType, value);
+            XElement propertyTag = property.ToXml();
+            typeConverter.Export(property, propertyTag, dependantNodes);
+            return propertyTag.Value;
+        }
+
+        /// <summary>
+        /// Invokes the Type Converter Import for an individual value inside the nested data type
+        /// </summary>
+        protected string NestedImport(IDataTypeConverter typeConverter, string value)
+        {
+            // recursively invoke the TypeConverter
+            XElement propertyTag = new XElement("Property", new XText(value));
+            return typeConverter.Import(propertyTag);
+        }
+
+        /// <summary>
+        /// Operation type flag, to use in shared processing methods
+        /// </summary>
+        protected enum OperationType
+        {
+            Export,
+            Import
+        }
+
+    }
+}

--- a/Conveyor/AST.ContentConveyor7/DataTypeConverters/MultipleMediaPickerDataTypeConverter.cs
+++ b/Conveyor/AST.ContentConveyor7/DataTypeConverters/MultipleMediaPickerDataTypeConverter.cs
@@ -1,0 +1,62 @@
+﻿namespace AST.ContentConveyor7.DataTypeConverters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using AST.ContentConveyor7;
+    using AST.ContentConveyor7.Enums;
+    using AST.ContentConveyor7.Utilities;
+
+    using Umbraco.Core.Models;
+
+    public class MultipleMediaPickerDataTypeConverter : BaseContentManagement, IDataTypeConverter
+    {
+        public void Export(Property property, XElement propertyTag, Dictionary<int, ObjectTypes> dependantNodes)
+        {
+            if (property.Value != null && !string.IsNullOrWhiteSpace(property.Value.ToString()))
+            {
+                var ids = property.Value.ToString().Split(',').Select(s => int.Parse(s));
+                List<string> guids = new List<string>(ids.Count());
+
+                foreach (int id in ids)
+                {
+                    var media = Services.MediaService.GetById(id);
+                    if (media != null)
+                    {
+                        guids.Add(media.Key.ToString());
+                        if (!dependantNodes.ContainsKey(media.Id))
+                        {
+                            dependantNodes.Add(media.Id, ObjectTypes.Media);
+                        }
+                    }
+                }
+                propertyTag.Value = String.Join(",", guids);
+            }
+        }
+
+        public string Import(XElement propertyTag)
+        {
+            var result = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(propertyTag.Value))
+            {
+                var guids = propertyTag.Value.Split(',').Select(s => new Guid(s));
+                List<string> ids = new List<string>(guids.Count());
+
+                foreach (Guid guid in guids)
+                {
+                    var media = Services.MediaService.GetById(guid);
+                    if (media != null)
+                    {
+                        ids.Add(media.Id.ToString());
+                    }
+                }
+                result = String.Join(",", ids);
+
+            }
+            return result;
+        }
+    }
+}

--- a/Conveyor/AST.ContentConveyor7/DataTypeConverters/NestedContentDataTypeConverter.cs
+++ b/Conveyor/AST.ContentConveyor7/DataTypeConverters/NestedContentDataTypeConverter.cs
@@ -1,0 +1,126 @@
+﻿namespace AST.ContentConveyor7.DataTypeConverters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    using AST.ContentConveyor7;
+    using AST.ContentConveyor7.Enums;
+    using AST.ContentConveyor7.Utilities;
+
+    using Umbraco.Core.Models;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Type Converter for a Nested Content field: recursively traverses the JSON data
+    /// and invokes other Type Converters when appropriate
+    /// </summary>
+    public class NestedContentDataTypeConverter : BaseNestedTypeConverter, IDataTypeConverter
+    {
+        /// <summary>
+        /// Export conversion
+        /// </summary>
+        public void Export(Property property, XElement propertyTag, Dictionary<int, ObjectTypes> dependantNodes)
+        {
+            string jsonText = (property.Value ?? "").ToString();
+            string newText = ProcessAll(jsonText, OperationType.Export, dependantNodes);
+
+            if (propertyTag.FirstNode is XCData)
+            {
+                // JSON was wrapped in CDATA tag - should do the same 
+                propertyTag.RemoveNodes();
+                propertyTag.Add(new XCData(newText));
+            }
+            else
+            {
+                // no CDATA (i.e. nested Nested Content)
+                propertyTag.Value = newText;
+            }
+        }
+
+        /// <summary>
+        /// Import conversion
+        /// </summary>
+        public string Import(XElement propertyTag)
+        {
+            string jsonText = (propertyTag.Value ?? "").ToString();
+            return ProcessAll(jsonText, OperationType.Import, null);
+        }
+
+        /// <summary>
+        /// Parse and process the full Nested Content JSON, for an Export or Import operation 
+        /// </summary>
+        private string ProcessAll(string jsonText, OperationType operation, Dictionary<int, ObjectTypes> dependantNodes)
+        {
+            if (!string.IsNullOrWhiteSpace(jsonText))
+            {
+                // deserialize JSON into JToken graph
+                var doc = JsonConvert.DeserializeObject(jsonText);
+                JArray jDocs;
+                JObject jDoc;
+
+                if ((jDocs = doc as JArray) != null)
+                {
+                    // process a multiple document Nested Component field
+                    foreach (JObject jDoc1 in jDocs)
+                    {
+                        ProcessDocument(jDoc1, operation, dependantNodes);
+                    }
+                    // re-serialize the updated JSON be returned
+                    jsonText = jDocs.ToString(Formatting.None);
+                }
+                else if ((jDoc = doc as JObject) != null)
+                {
+                    // process a single document Nested Component field
+                    ProcessDocument(jDoc, operation, dependantNodes);
+
+                    // re-serialize the updated JSON be returned
+                    jsonText = jDoc.ToString(Formatting.None);
+                }
+            }
+            return jsonText;
+        }
+
+        /// <summary>
+        /// Parse and process the a single document inside the Nested Content JSON, for an Export or Import operation 
+        /// </summary>
+        private void ProcessDocument(JObject jDoc, OperationType operation, Dictionary<int, ObjectTypes> dependantNodes)
+        {
+            // prepare dictionary of property types in the current Nested Content document type
+            string contentTypeAlias = jDoc["ncContentTypeAlias"].ToString();
+            IContentType contentType = Services.ContentTypeService.GetContentType(contentTypeAlias);
+            Dictionary<string, PropertyType> propertyTypeDictionary = contentType.CompositionPropertyTypes.ToDictionary(p => p.Alias);
+
+            // lookup each property present in the JSON data
+            foreach (JProperty jProperty in jDoc.Properties())
+            {
+                PropertyType propertyType;
+                string value;
+                if (!String.IsNullOrWhiteSpace(value = jProperty.Value.ToString())
+                    && propertyTypeDictionary.TryGetValue(jProperty.Name, out propertyType))
+                {
+                    // this is an actual field of the nested document type
+                    var guid = propertyType.DataTypeId;
+                    string typeAlias;
+
+                    // look for a custom TypeConverter for this field
+                    if (SpecialDataTypes.TryGetValue(guid, out typeAlias))
+                    {
+                        // found! then wrap the value in a Property to recursively invoke the TypeConverter
+                        var typeConverter = GetDataTypeConverterInterface(typeAlias);
+
+                        // invoke the Export / Import operation
+                        string newValue = operation == OperationType.Export?
+                            NestedExport(typeConverter, value, propertyType, dependantNodes):
+                            NestedImport(typeConverter, value);
+                        
+                        // update the JSON graph with the converted value
+                        jProperty.Value = newValue;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Conveyor/WebUIv7/config/ContentConveyor.config
+++ b/Conveyor/WebUIv7/config/ContentConveyor.config
@@ -8,6 +8,7 @@
     <DataType guid="cdbf0b5d-5cb2-445f-bc12-fcaaec07cf2c" type="AST.ContentConveyor7.DataTypeConverters.ContentPickerDataTypeConverter, AST.ContentConveyor7" />
     <DataType guid="a74ea9c9-8e18-4d2a-8cf6-73c6206c5da6" type="AST.ContentConveyor7.DataTypeConverters.DropdownListDataTypeConverter, AST.ContentConveyor7" />
     <DataType guid="5e9b75ae-face-41c8-b47e-5f4b0fd82f83" type="AST.ContentConveyor7.DataTypeConverters.RichTextEditorDataTypeConverter, AST.ContentConveyor7" /> 
+    <DataType guid="556d6272-6163-6f2e-4d75-6c7469706c65" type="AST.ContentConveyor7.DataTypeConverters.MultipleMediaPickerDataTypeConverter, AST.ContentConveyor7" />
 
   </SpecialDataTypes>
 

--- a/Conveyor/WebUIv7/config/ContentConveyor.config
+++ b/Conveyor/WebUIv7/config/ContentConveyor.config
@@ -9,6 +9,7 @@
     <DataType guid="a74ea9c9-8e18-4d2a-8cf6-73c6206c5da6" type="AST.ContentConveyor7.DataTypeConverters.DropdownListDataTypeConverter, AST.ContentConveyor7" />
     <DataType guid="5e9b75ae-face-41c8-b47e-5f4b0fd82f83" type="AST.ContentConveyor7.DataTypeConverters.RichTextEditorDataTypeConverter, AST.ContentConveyor7" /> 
     <DataType guid="556d6272-6163-6f2e-4d75-6c7469706c65" type="AST.ContentConveyor7.DataTypeConverters.MultipleMediaPickerDataTypeConverter, AST.ContentConveyor7" />
+    <DataType guid="4f75722e-556d-6272-6163-6f2e4e657374" type="AST.ContentConveyor7.DataTypeConverters.NestedContentDataTypeConverter, AST.ContentConveyor7" />
 
   </SpecialDataTypes>
 


### PR DESCRIPTION
In AST.ContentConveyor7, additional DataType converters are added to support the MultipleMediaPicker and the NestedContent property editors in Umbraco v7
